### PR TITLE
CHANGED default GDS shifts to 1 and in a way that actually works

### DIFF
--- a/templates/fastaval-deltager-2019/tilmelding_8_gds.php
+++ b/templates/fastaval-deltager-2019/tilmelding_8_gds.php
@@ -207,7 +207,7 @@
                     <h3><?php __etm('gds_how_many_headline');?></h3>
                     <p><?php __etm('gds_how_many_text');?>
                     <?php
-                        if (!isset($_SESSION['customer']['desired_diy_shifts'])) $_SESSION['customer']['desired_diy_shifts'] = 1;
+                        if (!isset($_SESSION['customer']['desired_diy_shifts']) && $_SESSION['customer']['participant'] == "deltager") $_SESSION['customer']['desired_diy_shifts'] = 1;
                 			renderFieldByType(array(
                     			'id'=>'desired_diy_shifts',
                     			'input-type'=>'text',

--- a/templates/fastaval-deltager-2019/tilmelding_8_gds.php
+++ b/templates/fastaval-deltager-2019/tilmelding_8_gds.php
@@ -207,11 +207,11 @@
                     <h3><?php __etm('gds_how_many_headline');?></h3>
                     <p><?php __etm('gds_how_many_text');?>
                     <?php
+                        if (!isset($_SESSION['customer']['desired_diy_shifts'])) $_SESSION['customer']['desired_diy_shifts'] = 1;
                 			renderFieldByType(array(
                     			'id'=>'desired_diy_shifts',
                     			'input-type'=>'text',
                     			'input-name'=>'desired_diy_shifts',
-                    			'default-value' => 3,
                     			'text' => __tm('gds_angiv_antal'),
                 			));
             			?>


### PR DESCRIPTION
Change the default value of how many GDS shifts the participant will do.
There was a default value of 3 in the code that wasn't used anywhere.
The default value of the input field is now set to 1 using the session variable.