### PR TITLE
CHANGED new label for organizer etc on page 2

### DIFF
--- a/templates/fastaval-deltager-2019/tilmelding_2.php
+++ b/templates/fastaval-deltager-2019/tilmelding_2.php
@@ -545,7 +545,7 @@
                                 			'deltager'=>'nocat_106',
                                 			'deltagerjunior'=>'nocat_deltagerjunior',
                                 			'--' => "<br>",
-                                			'arrangoer'=>'nocat_108',
+                                			'arrangoer'=>'nocat_organizer',
                                 			
                                 			/*
                                 			'--' => "<br>".__tm('page2_text19')."<br><br>",


### PR DESCRIPTION
Added a different label so the practical page can say something like "organizer etc", without changing the wording of "organizer" on the organizer detail page 

I've already added placeholder translation to language.xml on live