### PR TITLE
ADDED headline, text and input field for parent's kontakt info FV Junior

### DIFF
--- a/templates/fastaval-deltager-2019/tilmelding_3_fvjunior.php
+++ b/templates/fastaval-deltager-2019/tilmelding_3_fvjunior.php
@@ -44,6 +44,20 @@
                 <h2><?php __etm('fastaval_junior_headline_3');?></h2>
                 <p><?php __etm('fastaval_junior_text_3');?></p>
                 
+                <h2><?php __etm('fastaval_junior_headline_4');?></h2>
+                <p><?php __etm('fastaval_junior_text_4');?></p>
+
+                <div id='tilmelding-info'>
+                    <?php
+            			renderFieldByType(array(
+                			'id'=>'other_comments',
+                			'input-type'=>'textarea',
+                			'input-name'=>'other_comments',
+                			'text'=>'',
+            			));
+                    ?>
+                </div>
+
                 <?php tilm_form_postfields(); ?>
                 <?php render_next_button("general_next_page");?>
         	</form>


### PR DESCRIPTION
Added a headline, text and text input field on the Fastaval Junior page.
To avoid having to add extra fields in infosys, the input field is the same id as the one used for extra comments for regular participants, since Fastaval Junior participants don't use that field. 