### PR TITLE
CHANGED cleaned up some js code and added comments on activities page

### DIFF
--- a/templates/fastaval-deltager-2019/tilmelding_7_aktiviteter.php
+++ b/templates/fastaval-deltager-2019/tilmelding_7_aktiviteter.php
@@ -306,18 +306,23 @@
             <script>
                 jQuery(document).ready(function(){
                     
-                    jQuery('#aktiviteter tr.row-type-junior').addClass('hidden');
                     if (selectFilterType === "junior"){
-                        // do the  junior thing
+                        //Hide everything that isn't related to junior activities
+                        // hide type selector
                         jQuery(".type-selector").hide();
+                        // hide tables for days without junior activities
                         jQuery(".table-day").each( function (){
                             if(jQuery(this).find("tr.row-type-junior").length === 0){
                                 jQuery(this).hide();
                             }
                         });
+                        // hide all activities and show junior activities
                         jQuery('#aktiviteter tr.row-with-game').addClass('hidden');
                         jQuery('#aktiviteter tr.row-type-junior').removeClass('hidden');
                     } else if (selectFilterType!=""){
+                        // hide junior activities for normal participants
+                        jQuery('#aktiviteter tr.row-type-junior').addClass('hidden');
+                        // activate any filter set on a previous page
                         jQuery('#filter-'+selectFilterType).click();
                     }
                 });

--- a/templates/fastaval-deltager-2019/tilmelding_7_aktiviteter.php
+++ b/templates/fastaval-deltager-2019/tilmelding_7_aktiviteter.php
@@ -319,11 +319,13 @@
                         // hide all activities and show junior activities
                         jQuery('#aktiviteter tr.row-with-game').addClass('hidden');
                         jQuery('#aktiviteter tr.row-type-junior').removeClass('hidden');
-                    } else if (selectFilterType!=""){
+                    } else {
                         // hide junior activities for normal participants
                         jQuery('#aktiviteter tr.row-type-junior').addClass('hidden');
-                        // activate any filter set on a previous page
-                        jQuery('#filter-'+selectFilterType).click();
+                        if (selectFilterType!=""){
+                            // activate any filter set on a previous page
+                            jQuery('#filter-'+selectFilterType).click();
+                        }
                     }
                 });
             </script>


### PR DESCRIPTION
Added some comments to the in-line script on the activities page and changed it so it only hides the junior activities for regular partipants, instead of hiding them first and then right away showing them again if the person was signing up for Fastaval Junior.

At first I accidentally made it so the junior activities would only be hidden if a filter was selected, but since it's also filtered by age, I didn't notice it right away.