### PR TITLE
FIXED warning from missing argument

### DIFF
--- a/class.signuphandler.php
+++ b/class.signuphandler.php
@@ -12,7 +12,7 @@ class SignupHandler
         
         $this->signuppages = array();
         if (function_exists("myfunc_get_pages"))
-            $this->signuppages = myfunc_get_pages();
+            $this->signuppages = myfunc_get_pages(array());
     }
 
     public function init_signuppages()


### PR DESCRIPTION
It might have been better to set a default value in the function instead, but at least this gets rid of the constant warning